### PR TITLE
Fix AttributeError in ColormapRegistry

### DIFF
--- a/run.py
+++ b/run.py
@@ -1,7 +1,7 @@
 import argparse
 import cv2
 import glob
-import matplotlib
+import matplotlib.pyplot as plt
 import numpy as np
 import os
 import torch
@@ -47,7 +47,7 @@ if __name__ == '__main__':
     
     os.makedirs(args.outdir, exist_ok=True)
     
-    cmap = matplotlib.colormaps.get_cmap('Spectral_r')
+    cmap = plt.get_cmap('Spectral_r')
     
     for k, filename in enumerate(filenames):
         print(f'Progress {k+1}/{len(filenames)}: {filename}')


### PR DESCRIPTION
### Problem:
In the original code, the line:
`cmap = matplotlib.colormaps.get_cmap('Spectral_r')`

was causing the following error:
`AttributeError: 'ColormapRegistry' object has no attribute 'get_cmap'`

This error occurs because in newer versions of `matplotlib`, the method for retrieving colormaps has changed.

### Solution:
Replaced `matplotlib.colormaps.get_cmap('Spectral_r')` with `plt.get_cmap('Spectral_r'),` which is the correct method to access colormaps in matplotlib.

### Impact:
This change ensures compatibility with newer versions of matplotlib and resolves the `AttributeError`